### PR TITLE
Handling XML files with different encodings

### DIFF
--- a/gpx/xml.go
+++ b/gpx/xml.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"golang.org/x/net/html/charset"
 )
 
 const formattingTimelayout = "2006-01-02T15:04:05Z"
@@ -141,41 +143,52 @@ func ParseFile(fileName string) (*GPX, error) {
 
 	defer f.Close()
 
-	b, err := ioutil.ReadAll(f)
+	buf, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
 
-	return ParseBytes(b)
+	return ParseBytes(buf)
 }
 
 //ParseBytes parses GPX from bytes
-func ParseBytes(bytes []byte) (*GPX, error) {
-	version, err := guessGPXVersion(bytes)
+func ParseBytes(buf []byte) (*GPX, error) {
+
+	version, err := guessGPXVersion(buf)
 	if err != nil {
 		// Unknown version, try with 1.1
 		version = "1.1"
 	}
 
+	reader := bytes.NewReader(buf)
+	decoder := xml.NewDecoder(reader)
+	decoder.CharsetReader = charset.NewReaderLabel
+
 	if version == "1.0" {
+
 		g := &gpx10Gpx{}
-		err := xml.Unmarshal(bytes, &g)
+
+		err = decoder.Decode(&g)
 		if err != nil {
 			return nil, err
 		}
 
 		return convertFromGpx10Models(g), nil
-	} else if version == "1.1" {
+	}
+
+	if version == "1.1" {
+
 		g := &gpx11Gpx{}
-		err := xml.Unmarshal(bytes, &g)
+
+		err = decoder.Decode(&g)
 		if err != nil {
 			return nil, err
 		}
 
 		return convertFromGpx11Models(g), nil
-	} else {
-		return nil, errors.New("Invalid version:" + version)
 	}
+
+	return nil, errors.New("Invalid version:" + version)
 }
 
 //ParseString parses GPX from string

--- a/test_files/iso8859-1encoded.gpx
+++ b/test_files/iso8859-1encoded.gpx
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="ISO-8859-1" standalone="yes"?>
+<gpx
+ version="1.0"
+ creator="OziExplorer Version 3954q - http://www.oziexplorer.com"
+ xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+ xmlns="http://www.topografix.com/GPX/1/0"
+ xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+<time>2013-07-29T21:43:01Z</time>
+<bounds minlat="44.252050" minlon="20.545637" maxlat="44.280432" maxlon="20.682845"/>
+<wpt lat="44.2805478" lon="20.5402796">
+ <time>2013-07-29T23:40:30.453Z</time>
+ <name>1</name>
+</wpt>
+<wpt lat="44.2742944" lon="20.5537630">
+ <time>2013-07-29T23:40:33.218Z</time>
+ <name>2</name>
+</wpt>
+<wpt lat="44.2682041" lon="20.5735475">
+ <time>2013-07-29T23:40:38.296Z</time>
+ <name>3</name>
+</wpt>
+<wpt lat="44.2631424" lon="20.5922124">
+ <time>2013-07-29T23:41:02.750Z</time>
+ <name>4</name>
+</wpt>
+<wpt lat="44.2605571" lon="20.5987511">
+ <time>2013-07-29T23:41:12.984Z</time>
+ <name>5</name>
+</wpt>
+<wpt lat="44.2580210" lon="20.6104750">
+ <time>2013-07-29T23:41:26.437Z</time>
+ <name>6</name>
+</wpt>
+<wpt lat="44.2562587" lon="20.6382348">
+ <time>2013-07-29T23:41:50.375Z</time>
+ <name>7</name>
+</wpt>
+<wpt lat="44.2521762" lon="20.6774742">
+ <time>2013-07-29T23:42:00.625Z</time>
+ <name>8</name>
+</wpt>
+</gpx>


### PR DESCRIPTION
Some of the GPX files I worked with had non-UTF8 encoding, and `gpxgo` wasn't able to work with them.

I made some adjustments in XML handling to allow `gpxgo` to work with such files, and added a test file with `ISO-8859-1` encoding to demonstrate the difference. Previously tests would crash if such file existed (because of missing error checks since certain cases weren't expected).