### PR TITLE
Remove unused 'fmt' import

### DIFF
--- a/gpx/geo.go
+++ b/gpx/geo.go
@@ -6,7 +6,6 @@
 package gpx
 
 import (
-	"fmt"
 	"math"
 	"sort"
 )


### PR DESCRIPTION
Library fails to build currently because of this extra `fmt` import.