### PR TITLE
Fix loading timestamps from Garmin watches

### DIFF
--- a/gpx/xml.go
+++ b/gpx/xml.go
@@ -23,6 +23,7 @@ const formattingTimelayout = "2006-01-02T15:04:05Z"
 var parsingTimelayouts = []string{
 	"2006-01-02T15:04:05.000Z",
 	formattingTimelayout,
+	"2006-01-02T15:04:05+00:00",
 	"2006-01-02T15:04:05",
 	"2006-01-02 15:04:05Z",
 	"2006-01-02 15:04:05",


### PR DESCRIPTION
Garmin watches produce timestamps in the following format:

    <time>2021-06-19T17:28:22+00:00</time>

This format is not covered by the existing layout strings.