### PR TITLE
Include extension in root path

### DIFF
--- a/gpx/gpx11.go
+++ b/gpx/gpx11.go
@@ -162,16 +162,17 @@ type gpx11Gpx struct {
 	AuthorName  string         `xml:"metadata>author>name,omitempty"`
 	AuthorEmail *gpx11GpxEmail `xml:"metadata>author>email,omitempty"`
 	// TODO: There can be more than one link?
-	AuthorLink *gpx11GpxLink      `xml:"metadata>author>link,omitempty"`
-	Copyright  *gpx11GpxCopyright `xml:"metadata>copyright,omitempty"`
-	Link       *gpx11GpxLink      `xml:"metadata>link,omitempty"`
-	Timestamp  string             `xml:"metadata>time,omitempty"`
-	Keywords   string             `xml:"metadata>keywords,omitempty"`
-	Extensions Extension          `xml:"metadata>extensions"`
-	Bounds     *gpx11GpxBounds    `xml:"bounds"`
-	Waypoints  []*gpx11GpxPoint   `xml:"wpt"`
-	Routes     []*gpx11GpxRte     `xml:"rte"`
-	Tracks     []*gpx11GpxTrk     `xml:"trk"`
+	AuthorLink         *gpx11GpxLink      `xml:"metadata>author>link,omitempty"`
+	Copyright          *gpx11GpxCopyright `xml:"metadata>copyright,omitempty"`
+	Link               *gpx11GpxLink      `xml:"metadata>link,omitempty"`
+	Timestamp          string             `xml:"metadata>time,omitempty"`
+	Keywords           string             `xml:"metadata>keywords,omitempty"`
+	MetadataExtensions Extension          `xml:"metadata>extensions"`
+	Bounds             *gpx11GpxBounds    `xml:"bounds"`
+	Waypoints          []*gpx11GpxPoint   `xml:"wpt"`
+	Routes             []*gpx11GpxRte     `xml:"rte"`
+	Tracks             []*gpx11GpxTrk     `xml:"trk"`
+	Extensions         Extension          `xml:"extensions"`
 }
 
 type gpx11GpxBounds struct {


### PR DESCRIPTION
in gpx created with osmand+ or Suunto include extensions that are not stored

Examples:

```
.
.
.
			<trkpt lat="40.085555" lon="0.142032">
				<ele>2.06320048610214</ele>
				<time>2019-09-08T18:46:20Z</time>
				<extensions>
					<gpxtpx:TrackPointExtension gpxtpx:gpxtpx="http://www.garmin.com/xmlschemas/TrackPointExtension/v1">
						<gpxtpx:hr>93</gpxtpx:hr>
					</gpxtpx:TrackPointExtension>
					<gpxdata:temp>25.8999996185303</gpxdata:temp>
					<gpxdata:distance>39455</gpxdata:distance>
					<gpxdata:altitude>2.06320048610214</gpxdata:altitude>
					<gpxdata:seaLevelPressure>1015.92999267578</gpxdata:seaLevelPressure>
					<gpxdata:speed>1.93160021920921</gpxdata:speed>
					<gpxdata:verticalSpeed>0</gpxdata:verticalSpeed>
				</extensions>
			</trkpt>
		</trkseg>
	</trk>
	<extensions>
		<gpxdata:lap>
			<gpxdata:index>1</gpxdata:index>
			<gpxdata:startTime>2019-09-08T15:47:49.670Z</gpxdata:startTime>
			<gpxdata:elapsedTime>0</gpxdata:elapsedTime>
			<gpxdata:distance>0</gpxdata:distance>
		</gpxdata:lap>
		<gpxdata:lap>
			<gpxdata:index>2</gpxdata:index>
			<gpxdata:startTime>2019-09-08T15:47:49.670Z</gpxdata:startTime>
			<gpxdata:elapsedTime>0</gpxdata:elapsedTime>
			<gpxdata:distance>0</gpxdata:distance>
		</gpxdata:lap>
		<gpxdata:lap>
			<gpxdata:index>3</gpxdata:index>
			<gpxdata:startTime>2019-09-08T16:20:18.203Z</gpxdata:startTime>
			<gpxdata:elapsedTime>1949</gpxdata:elapsedTime>
			<gpxdata:distance>9996</gpxdata:distance>
		</gpxdata:lap>
		<gpxdata:lap>
			<gpxdata:index>4</gpxdata:index>
			<gpxdata:startTime>2019-09-08T17:07:12.433Z</gpxdata:startTime>
			<gpxdata:elapsedTime>2814</gpxdata:elapsedTime>
			<gpxdata:distance>10000</gpxdata:distance>
		</gpxdata:lap>
		<gpxdata:lap>
			<gpxdata:index>5</gpxdata:index>
			<gpxdata:startTime>2019-09-08T17:49:38.503Z</gpxdata:startTime>
			<gpxdata:elapsedTime>2546</gpxdata:elapsedTime>
			<gpxdata:distance>10002</gpxdata:distance>
		</gpxdata:lap>
		<gpxdata:lap>
			<gpxdata:index>6</gpxdata:index>
			<gpxdata:startTime>2019-09-08T18:46:24.283Z</gpxdata:startTime>
			<gpxdata:elapsedTime>3406</gpxdata:elapsedTime>
			<gpxdata:distance>9469</gpxdata:distance>
		</gpxdata:lap>
	</extensions>
</gp>
```

```
.
.
.
			<trkpt lat="42.649122" lon="-0.0579352">
				<ele>1356</ele>
				<time>2023-03-26T12:35:23Z</time>
				<hdop>4.1</hdop>
				<extensions>
					<osmand:speed>0</osmand:speed>
					<osmand:heading>0</osmand:heading>
				</extensions>
			</trkpt>
		</trkseg>
	</trk>
	<extensions>
		<osmand:show_arrows>false</osmand:show_arrows>
		<osmand:show_start_finish>true</osmand:show_start_finish>
		<osmand:split_interval>0.0</osmand:split_interval>
		<osmand:split_type>no_split</osmand:split_type>
		<osmand:coloring_type>solid</osmand:coloring_type>
		<osmand:smoothing_threshold>0.0</osmand:smoothing_threshold>
		<osmand:min_filter_speed>0.0</osmand:min_filter_speed>
		<osmand:max_filter_speed>0.0</osmand:max_filter_speed>
		<osmand:min_filter_altitude>0.0</osmand:min_filter_altitude>
		<osmand:max_filter_altitude>0.0</osmand:max_filter_altitude>
		<osmand:max_filter_hdop>0.0</osmand:max_filter_hdop>
	</extensions>
</gp>
```
