### PR TITLE
set Strict false

### DIFF
--- a/gpx/xml.go
+++ b/gpx/xml.go
@@ -179,6 +179,7 @@ func Parse(inReader io.Reader) (*GPX, error) {
 
 	reader := io.MultiReader(bytes.NewReader(buf), inReader)
 	decoder := xml.NewDecoder(reader)
+	decoder.Strict = false
 	decoder.CharsetReader = charset.NewReaderLabel
 
 	switch version {


### PR DESCRIPTION
example , when &  in xml file , error 

```
 line 2  invalid character entity & (no semicolon)
```

so, set  Strict is false as default  config.


###  gpx file

```
<?xml version="1.0" encoding="UTF-8"?>
<gpx xmlns="http://www.topografix.com/GPX/1/1" version="1.1" creator="Chengdu Ledong Information & Technology Co., Ltd. ">
	<metadata>
		<name>Codoon_Sport_Record</name>
		<desc>Codoon_Sport_2024-04-04 08:09:35</desc>
		<author>
			<name><![CDATA[咚友e0aRk5aXGb]]></name>
		</author>
		<time>2024-04-04T12:07:17Z</time>
	</metadata>
	....
</xml>	
```


### Reference 

 https://github.com/golang/go/issues/35389
